### PR TITLE
Append V6 to deploy salts

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -7,7 +7,7 @@ import {Script, stdJson, VmSafe} from "forge-std/Script.sol";
 import "src/JBAddressRegistry.sol";
 
 contract Deploy is Script, Sphinx {
-    bytes32 constant ADDRESS_REGISTRY_SALT = "_JBAddressRegistry_";
+    bytes32 constant ADDRESS_REGISTRY_SALT = "_JBAddressRegistryV6_";
 
     function configureSphinx() public override {
         // TODO: Update to contain JB Emergency Developers


### PR DESCRIPTION
## Summary
- Updated `ADDRESS_REGISTRY_SALT` from `_JBAddressRegistry_` to `_JBAddressRegistryV6_`

Ensures all V6 contracts deploy to different deterministic addresses than V5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)