### PR TITLE
chore: standardize slither CI, convert positional args to named params

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    env:
+      NODE_ENV: production
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,7 +21,7 @@ jobs:
         with:
           node-version: latest
       - name: Install npm dependencies
-        run: npm ci
+        run: npm ci --production
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Run slither

--- a/src/JBAddressRegistry.sol
+++ b/src/JBAddressRegistry.sol
@@ -30,10 +30,10 @@ contract JBAddressRegistry is IJBAddressRegistry {
     /// @param nonce The nonce used to deploy the contract.
     function registerAddress(address deployer, uint256 nonce) external override {
         // Calculate the address of the contract, assuming it was deployed using `create` with the specified nonce.
-        address hook = _addressFrom(deployer, nonce);
+        address hook = _addressFrom({origin: deployer, nonce: nonce});
 
         // Register the contract using the calculated address.
-        _registerAddress(hook, deployer);
+        _registerAddress({addr: hook, deployer: deployer});
     }
 
     /// @notice Register a deployed contract's address.
@@ -50,7 +50,7 @@ contract JBAddressRegistry is IJBAddressRegistry {
             address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), deployer, salt, keccak256(bytecode))))));
 
         // Register the contract using the calculated address.
-        _registerAddress(hook, deployer);
+        _registerAddress({addr: hook, deployer: deployer});
     }
 
     //*********************************************************************//


### PR DESCRIPTION
## Summary
- Standardize slither workflow (add `NODE_ENV: production`, `npm ci --production`)
- Convert 3 positional function calls to named parameters in JBAddressRegistry.sol

## Test plan
- [x] `forge build` passes
- [ ] `forge test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)